### PR TITLE
fix: standardize output key naming and update references in action.yaml

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -13,9 +13,9 @@ outputs:
   new-tag:
     description: The new release tag (e.g., Rel-004-20250702191245)
     value: ${{ steps.generate-tag.outputs.new_tag }}
-  release_url:
+  release-url:
     description: The URL of the created draft release
-    value: ${{ steps.create-release.outputs.release_url }}
+    value: ${{ steps.create-release.outputs.release-url }}
 
 runs:
   using: "composite"
@@ -34,11 +34,13 @@ runs:
       uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        ref: ${{ steps.set-ref.outputs.ref }}
+
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        ref: ${{ steps.set-ref.outputs.ref }}
-
+        python-version: '3.x'
+        
     - name: Get current UTC timestamp
       id: time
       shell: bash
@@ -112,7 +114,7 @@ runs:
         fi
 
         html_url=$(gh release view "$tag" --json url --jq '.url')
-        echo "release_url=$html_url" >> "$GITHUB_OUTPUT"
+        echo "release-url=$html_url" >> "$GITHUB_OUTPUT"
 
     - name: Show release link
       shell: bash
@@ -124,7 +126,7 @@ runs:
         echo "" >> "$GITHUB_STEP_SUMMARY"
         echo "🆔 **Tag**: \`$tag\`" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
-        echo "🔗 **[View Draft Release](${{ steps.create-release.outputs.release_url }})**" >> "$GITHUB_STEP_SUMMARY"
+        echo "🔗 **[View Draft Release](${{ steps.create-release.outputs.release-url }})**" >> "$GITHUB_STEP_SUMMARY"
         echo "" >> "$GITHUB_STEP_SUMMARY"
 
 


### PR DESCRIPTION
This pull request makes several updates to the `action.yaml` file to standardize output variable naming conventions and correct configuration settings in the GitHub Actions workflow. The most important changes focus on renaming the release URL output variable from `release_url` to `release-url` throughout the workflow, as well as correcting the setup for the Python environment.

**Output variable naming standardization:**

* Changed the output variable name from `release_url` to `release-url` in the `outputs` section and updated all references accordingly, ensuring consistency and preventing potential errors. [[1]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL16-R18) [[2]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL115-R117) [[3]](diffhunk://#diff-fab4d7fb461bc6fbe9587f6c03fff98102b1c744145edcf2a993f2ff7cb05a0dL127-R129)

**Workflow configuration corrections:**

* Moved the `ref` input for `actions/checkout` to the correct step and set the `python-version` for `actions/setup-python` to `'3.x'`, fixing a misconfiguration where `ref` was incorrectly applied to the Python setup step.